### PR TITLE
Magento EE FPC Support

### DIFF
--- a/app/code/community/Turnto/Client/Block/Checkoutchatterpdp.php
+++ b/app/code/community/Turnto/Client/Block/Checkoutchatterpdp.php
@@ -5,26 +5,27 @@ class Turnto_Client_Block_Checkoutchatterpdp extends Mage_Core_Block_Template
     const TURNTO_CC_PDP_CACHE_TAG = 'TURNTO_CC_PDP_CACHE_TAG';
     const TURNTO_CC_PDP_CACHE_KEY = 'TURNTO_CC_PDP_CACHE_KEY';
 
-    public function __construct()
+    public function getCacheKey()
     {
-        // cache by store, http(s), package, theme
-        $this->addData(array(
-            // defaults to 15 minutes
-            'cache_lifetime' => Mage::getStoreConfig('turnto_admin/general/cc_display_cache_time') ? intval(Mage::getStoreConfig('turnto_admin/general/cc_display_cache_time')) : 900,
-            'cache_tags' => array(
-                $this::TURNTO_CC_PDP_CACHE_TAG,
-                Mage_Catalog_Model_Product::CACHE_TAG,
-                Mage::app()->getStore()->getId(),
-                (int)Mage::app()->getStore()->isCurrentlySecure(),
-                Mage::getDesign()->getPackageName(),
-                Mage::getDesign()->getTheme('template')
-            ),
-            'cache_key' => $this::TURNTO_CC_PDP_CACHE_KEY . $this->getProduct()->getId()
-        ));
+        $helper = Mage::helper('turnto_client_helper/data');
+        return $this::TURNTO_CC_PDP_CACHE_KEY . $helper->getProduct()->getId();
     }
 
-    public function getProduct()
+    public function getCacheLifetime()
     {
-        return Mage::registry('current_product');
+        return Mage::getStoreConfig('turnto_admin/general/cc_display_cache_time') ? intval(Mage::getStoreConfig('turnto_admin/general/cc_display_cache_time')) : 900;
     }
+
+    public function getCacheTags()
+    {
+        return array(
+            $this::TURNTO_CC_PDP_CACHE_TAG,
+            Mage_Catalog_Model_Product::CACHE_TAG,
+            Mage::app()->getStore()->getId(),
+            (int)Mage::app()->getStore()->isCurrentlySecure(),
+            Mage::getDesign()->getPackageName(),
+            Mage::getDesign()->getTheme('template')
+        );
+    }    
+
 }

--- a/app/code/community/Turnto/Client/Block/Qacontent.php
+++ b/app/code/community/Turnto/Client/Block/Qacontent.php
@@ -8,25 +8,29 @@ class Turnto_Client_Block_Qacontent extends Mage_Core_Block_Template
     const TURNTO_STATIC_EMBED = 'staticEmbed';
     const TURNTO_DYNAMIC_EMBED = 'dynamicEmbed';
 
-    public function __construct()
+    public function getCacheKey()
     {
         $helper = Mage::helper('turnto_client_helper/data');
-        //parent::construct();
-        $this->addData(array(
-            // defaults to 15 minutes
-            'cache_lifetime' => Mage::getStoreConfig('turnto_admin/general/static_cache_time') ? intval(Mage::getStoreConfig('turnto_admin/general/static_cache_time')) : 900,
-            'cache_tags' => array(
-                $this::TURNTO_QA_STATIC_CACHE_TAG,
-                Mage_Catalog_Model_Product::CACHE_TAG,
-                Mage::app()->getStore()->getId(),
-                (int)Mage::app()->getStore()->isCurrentlySecure(),
-                Mage::getDesign()->getPackageName(),
-                Mage::getDesign()->getTheme('template'),
-                Mage::getStoreConfig('turnto_admin/qa/qa_setup_type')
-                // todo: add tra version so that it clears the cache with the version is changed?
-            ),
-            'cache_key' => $this::TURNTO_QA_STATIC_CACHE_KEY . $helper->getProduct()->getId()
-        ));
+        return $this::TURNTO_QA_STATIC_CACHE_KEY . $helper->getProduct()->getId();
+    }
+
+    public function getCacheLifetime()
+    {
+        return Mage::getStoreConfig('turnto_admin/general/static_cache_time') ? intval(Mage::getStoreConfig('turnto_admin/general/static_cache_time')) : 900;
+    }
+
+    public function getCacheTags()
+    {
+        return array(
+            $this::TURNTO_QA_STATIC_CACHE_TAG,
+            Mage_Catalog_Model_Product::CACHE_TAG,
+            Mage::app()->getStore()->getId(),
+            (int)Mage::app()->getStore()->isCurrentlySecure(),
+            Mage::getDesign()->getPackageName(),
+            Mage::getDesign()->getTheme('template'),
+            Mage::getStoreConfig('turnto_admin/qa/qa_setup_type')
+            // todo: add tra version so that it clears the cache with the version is changed?
+        );
     }
 
     public function getQAHtml()

--- a/app/code/community/Turnto/Client/Block/Qateaser.php
+++ b/app/code/community/Turnto/Client/Block/Qateaser.php
@@ -5,21 +5,35 @@ class Turnto_Client_Block_Qateaser extends Mage_Core_Block_Template
     const TURNTO_QA_TEASERS_CACHE_TAG = 'TURNTO_QA_TEASERS_CACHE_TAG';
     const TURNTO_QA_TEASERS_CACHE_KEY = 'TURNTO_QA_TEASERS_CACHE_KEY';
 
-    public function __construct()
+    public function getCacheKey(){
+        return $this::TURNTO_QA_TEASERS_CACHE_KEY;
+    }
+
+    public function getCacheKeyInfo()
     {
-        // cache by store, http(s), package, theme
-        $this->addData(array(
-            // defaults to 15 minutes
-            'cache_lifetime' => Mage::getStoreConfig('turnto_admin/general/teaser_cache_time') ? intval(Mage::getStoreConfig('turnto_admin/general/teaser_cache_time')) : 900,
-            'cache_tags' => array(
-                $this::TURNTO_QA_TEASERS_CACHE_TAG,
-                Mage_Catalog_Model_Product::CACHE_TAG,
-                Mage::app()->getStore()->getId(),
-                (int)Mage::app()->getStore()->isCurrentlySecure(),
-                Mage::getDesign()->getPackageName(),
-                Mage::getDesign()->getTheme('template')
-            ),
-            'cache_key' => $this::TURNTO_QA_TEASERS_CACHE_KEY
-        ));
+        $helper = Mage::helper('turnto_client_helper/data');
+        $info = parent::getCacheKeyInfo();
+        if ($helper->getProduct())
+        {
+            $info['product_id'] = $helper->getProduct()->getId();
+        }
+        return $info;
+    }
+
+    public function getCacheLifetime()
+    {
+        return Mage::getStoreConfig('turnto_admin/general/teaser_cache_time') ? intval(Mage::getStoreConfig('turnto_admin/general/teaser_cache_time')) : 900;
+    }
+
+    public function getCacheTags()
+    {
+        return array(
+            $this::TURNTO_QA_TEASERS_CACHE_TAG,
+            Mage_Catalog_Model_Product::CACHE_TAG,
+            Mage::app()->getStore()->getId(),
+            (int)Mage::app()->getStore()->isCurrentlySecure(),
+            Mage::getDesign()->getPackageName(),
+            Mage::getDesign()->getTheme('template')
+        );
     }
 }

--- a/app/code/community/Turnto/Client/Block/Reviewscontent.php
+++ b/app/code/community/Turnto/Client/Block/Reviewscontent.php
@@ -7,25 +7,29 @@ class Turnto_Client_Block_Reviewscontent extends Mage_Core_Block_Template
     const TURNTO_STATIC_EMBED = 'staticEmbed';
     const TURNTO_DYNAMIC_EMBED = 'dynamicEmbed';
 
-    public function __construct()
+    public function getCacheKey()
     {
         $helper = Mage::helper('turnto_client_helper/data');
-        //parent::construct();
-        $this->addData(array(
-            // defaults to 15 minutes
-            'cache_lifetime' => Mage::getStoreConfig('turnto_admin/general/static_cache_time') ? intval(Mage::getStoreConfig('turnto_admin/general/static_cache_time')) : 900,
-            'cache_tags' => array(
-                $this::TURNTO_REVIEWS_STATIC_CACHE_TAG,
-                Mage_Catalog_Model_Product::CACHE_TAG,
-                Mage::app()->getStore()->getId(),
-                (int)Mage::app()->getStore()->isCurrentlySecure(),
-                Mage::getDesign()->getPackageName(),
-                Mage::getDesign()->getTheme('template'),
-                Mage::getStoreConfig('turnto_admin/reviews/reviews_setup_type')
-            ),
-            'cache_key' => $this::TURNTO_REVIEW_STATIC_CACHE_KEY . $helper->getProduct()->getId()
-        ));
+        return $this::TURNTO_REVIEW_STATIC_CACHE_KEY . $helper->getProduct()->getId();
     }
+
+    public function getCacheLifetime()
+    {
+        return Mage::getStoreConfig('turnto_admin/general/static_cache_time') ? intval(Mage::getStoreConfig('turnto_admin/general/static_cache_time')) : 900;
+    }
+
+    public function getCacheTags()
+    {
+        return array(
+            $this::TURNTO_REVIEWS_STATIC_CACHE_TAG,
+            Mage_Catalog_Model_Product::CACHE_TAG,
+            Mage::app()->getStore()->getId(),
+            (int)Mage::app()->getStore()->isCurrentlySecure(),
+            Mage::getDesign()->getPackageName(),
+            Mage::getDesign()->getTheme('template'),
+            Mage::getStoreConfig('turnto_admin/reviews/reviews_setup_type')
+        );
+    } 
 
     public function getReviewsHtml()
     {

--- a/app/code/community/Turnto/Client/Block/Reviewsteaser.php
+++ b/app/code/community/Turnto/Client/Block/Reviewsteaser.php
@@ -5,21 +5,25 @@ class Turnto_Client_Block_Reviewsteaser extends Mage_Core_Block_Template
     const TURNTO_REVIEW_TEASERS_CACHE_TAG = 'TURNTO_REVIEW_TEASERS_CACHE_TAG';
     const TURNTO_REVIEW_TEASERS_CACHE_KEY = 'TURNTO_REVIEW_TEASERS_CACHE_KEY';
 
-    public function __construct()
+    public function getCacheKey()
     {
-        // cache by store, http(s), package, theme
-        $this->addData(array(
-            // defaults to 15 minutes
-            'cache_lifetime' => Mage::getStoreConfig('turnto_admin/general/teaser_cache_time') ? intval(Mage::getStoreConfig('turnto_admin/general/teaser_cache_time')) : 900,
-            'cache_tags' => array(
-                $this::TURNTO_REVIEW_TEASERS_CACHE_TAG,
-                Mage_Catalog_Model_Product::CACHE_TAG,
-                Mage::app()->getStore()->getId(),
-                (int)Mage::app()->getStore()->isCurrentlySecure(),
-                Mage::getDesign()->getPackageName(),
-                Mage::getDesign()->getTheme('template')
-            ),
-            'cache_key' => $this::TURNTO_REVIEW_TEASERS_CACHE_KEY
-        ));
+        return $this::TURNTO_REVIEW_TEASERS_CACHE_KEY;
     }
+
+    public function getCacheLifetime()
+    {
+        return Mage::getStoreConfig('turnto_admin/general/teaser_cache_time') ? intval(Mage::getStoreConfig('turnto_admin/general/teaser_cache_time')) : 900;
+    }
+
+    public function getCacheTags()
+    {
+        return array(
+            $this::TURNTO_REVIEW_TEASERS_CACHE_TAG,
+            Mage_Catalog_Model_Product::CACHE_TAG,
+            Mage::app()->getStore()->getId(),
+            (int)Mage::app()->getStore()->isCurrentlySecure(),
+            Mage::getDesign()->getPackageName(),
+            Mage::getDesign()->getTheme('template')
+        );
+    } 
 }

--- a/app/code/community/Turnto/Client/Block/Vcgallery.php
+++ b/app/code/community/Turnto/Client/Block/Vcgallery.php
@@ -5,27 +5,28 @@ class Turnto_Client_Block_Vcgallery extends Mage_Core_Block_Template
     const TURNTO_VC_GALLERY_CACHE_TAG = 'TURNTO_VC_GALLERY_CACHE_TAG';
     const TURNTO_VC_GALLERY_CACHE_KEY = 'TURNTO_VC_GALLERY_CACHE_KEY';
 
-    public function __construct()
+    public function getCacheKey()
     {
         $helper = Mage::helper('turnto_client_helper/data');
-        //parent::construct();
-        $this->addData(array(
-            // defaults to 15 minutes
-            'cache_lifetime' => Mage::getStoreConfig('turnto_admin/general/vcgallery_cache_time') ? intval(Mage::getStoreConfig('turnto_admin/general/vcgallery_cache_time')) : 900,
-            'cache_tags' => array(
-                $this::TURNTO_VC_GALLERY_CACHE_TAG,
-                Mage_Catalog_Model_Product::CACHE_TAG,
-                Mage::app()->getStore()->getId(),
-                (int)Mage::app()->getStore()->isCurrentlySecure(),
-                Mage::getDesign()->getPackageName(),
-                Mage::getDesign()->getTheme('template')
-            ),
-            'cache_key' => $this::TURNTO_VC_GALLERY_CACHE_KEY . $this->getProduct()->getId()
-        ));
+        return $this::TURNTO_VC_GALLERY_CACHE_KEY . $helper->getProduct()->getId();
     }
 
-    public function getProduct()
+    public function getCacheLifetime()
     {
-        return Mage::registry('current_product');
+        return Mage::getStoreConfig('turnto_admin/general/vcgallery_cache_time') ? intval(Mage::getStoreConfig('turnto_admin/general/vcgallery_cache_time')) : 900;
     }
+
+    public function getCacheTags()
+    {
+        return array(
+            $this::TURNTO_VC_GALLERY_CACHE_TAG,
+            Mage_Catalog_Model_Product::CACHE_TAG,
+            Mage::app()->getStore()->getId(),
+            (int)Mage::app()->getStore()->isCurrentlySecure(),
+            Mage::getDesign()->getPackageName(),
+            Mage::getDesign()->getTheme('template')
+        );
+    } 
+
+    
 }


### PR DESCRIPTION
Hello,

This PR moves some block caching logic out of the class constructors, and into block class methods. In practice, this modification should allow the extension to function the same, but it helps out with FPC caching. In Magento's FPC mode, the constructors would try to call methods and retrieve data not available during the FPC processes, which would throw an error.

Moving that logic out of the constructor allows Magento to instantiate the class in FPC mode.

Thank you! Please let me know if you have any questions.
Rob